### PR TITLE
Fixes for use on Windows

### DIFF
--- a/rdd-to-ascii.py
+++ b/rdd-to-ascii.py
@@ -1,5 +1,6 @@
 # 1601, Fri  8 Sep 2023 (NZST)
 # 1504, Tue 26 Sep 2023 (NZDT)
+# 1553, Sat 21 Oct 2023 (NZDT)
 #
 # rdd-to-ascii.py: Convert an rfc-draw .rdd file to an ASCII ART image;
 #
@@ -210,10 +211,13 @@ class asc_drawing:
 
 if __name__ == "__main__":
     #print("argv >%s<, len(sys.argv) = %d" % (sys.argv, len(sys.argv)))
+    rdd_fn = None
     if len(sys.argv) == 1:  # sys.argv[0] = name of program 
         print("No .rdd file specified ???")
-        exit()
-    rdd_fn = sys.argv[1]
+        from tkinter.filedialog import askopenfilename
+        rdd_fn = (askopenfilename(title="Select .rdd source file"))
+    if not rdd_fn:
+        rdd_fn = sys.argv[1]
     rdd_name = rdd_fn.split(".rdd")
     if len(rdd_name) != 2:
         print("\ardd filename >%s< didn't end with '.rdd", rdd_fn)

--- a/rdd-to-svg.py
+++ b/rdd-to-svg.py
@@ -1,5 +1,6 @@
 # 1549, Fri  8 Sep 2023 (NZST)
 # 1529, Tue 30 May 2023 (NZST)
+# 1544, Sat 21 Oct 2023 (NZDT)
 #
 # rdd-to-svg.py: Convert an rfc-draw .rdd file to an svg image;
 #   that svg image >>> conforms to RFC 7996 requirements <<<
@@ -174,9 +175,12 @@ class svg_drawing:
 
 if __name__ == "__main__":
     #print("argv >%s<, len(sys.argv) = %d" % (sys.argv, len(sys.argv)))
+    rdd_fn = None
     if len(sys.argv) == 1:  # sys.argv[0] = name of program 
         print("No .rdd file specified ???")
-        exit()
+        from tkinter.filedialog import askopenfilename
+        rdd_fn = (askopenfilename(title="Select .rdd source file"))
+
 
     # python3 rdd-to-svg.py  group-line-test.rdd     -> no border around image
     # python3 rdd-to-svg.py  group-line-test.rdd -b  -> 3 px border
@@ -184,7 +188,8 @@ if __name__ == "__main__":
     
     border_width = 3  # Default value
     #print("sys.argv >%s<" % sys.argv)
-    rdd_fn = sys.argv[1]
+    if not rdd_fn:
+        rdd_fn = sys.argv[1]
     if len(sys.argv) >= 3:  # We have a second argument
         arg2 = sys.argv[2]
         if len(arg2) >= 2:

--- a/rfc-draw.py
+++ b/rfc-draw.py
@@ -1,5 +1,6 @@
 # 1232, Wed 28 Sep 2022 (NZDT)
-# 1603, Sat  1 Oct 2023 (NZDT)
+# 1603, Sun  1 Oct 2023 (NZDT)
+# 1613, Sat 21 Oct 2023 (NZDT)
 #
 # rfc-draw: Nevil's tkinter program to draw images for SVG-RFC-1.2 diagrams
 #
@@ -126,8 +127,12 @@ if len(sys.argv) == 2:
     if sys.argv[1][-4:] != ".rdd":
         print("\a\aExpected to Save to an .rdd file <<<")
 else:
-    save_file_name = "save-file.rdd"
-    rdg.display_msg("No file %s, will write it on closing" % save_file_name,
+    save_file_name = None
+    from tkinter.filedialog import askopenfilename
+    save_file_name = (askopenfilename(title="Select .rdd file; cancel box if none"))
+    if not save_file_name:    
+        save_file_name = "save-file.rdd"
+        rdg.display_msg("No file %s, will write it on closing" % save_file_name,
         "warning")
 
 dlc_tool = dlc.draw_lines(d_canvas.drawing, root, rdg)

--- a/rfc_draw_globals_class.py
+++ b/rfc_draw_globals_class.py
@@ -1,7 +1,8 @@
 # 1055, Wed  6 Sep 2023 (NZST)
 # 1600, Tue 25 Jul 2023 (NZST)
 # 1411, Sun 22 Jan 2023 (NZDT)
-# 1609, Sat  1 Oct 2023 (NZDT)
+# 1609, Sun  1 Oct 2023 (NZDT)
+# 1531, Sat 21 Oct 2023 (NZDT)
 #
 # rfc_draw_globals_class:
 #                   contains rfc-draw global data (for event handlers)
@@ -12,7 +13,11 @@
 #                      
 # Copyright 2023, Nevil Brownlee, Taupo NZ
 
-import os.path, re, sys, termios, traceback
+import os.path, re, sys, traceback
+try:
+    import termios  # This is POSIX
+except:
+    import msvcrt   # This is Windows
 import tkinter as tk
 
 import arrow_lines_class as alc   # Draw lines with direction arrows
@@ -123,8 +128,13 @@ class rdglob:  # Global variables for rfc-draw's objects
         self.bind_keys()
 
     def bind_keys(self):
-        termios.tcflush(sys.stdin, termios.TCIOFLUSH)
-            # Clear queued key-presses
+        try:
+            # Clear queued key-presses on POSIX
+            termios.tcflush(sys.stdin, termios.TCIOFLUSH)        
+        except:
+            # Clear queued key-presses on Windows
+            while msvcrt.kbhit():
+                msvcrt.getch()
         self.root.bind('<KeyPress>', self.on_key_press_repeat)
         self.has_prev_key_press = None
         self.root.bind('<Escape>',self.on_key_press_repeat) # Clear Msg window


### PR DESCRIPTION
1. Use msvcrt if termios absent
2. Use askopenfilename if no filename on command line